### PR TITLE
允许子类重写获得数据库对象逻辑

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# PyCharm
+.idea/

--- a/vnpy_datarecorder/engine.py
+++ b/vnpy_datarecorder/engine.py
@@ -52,12 +52,15 @@ class RecorderEngine(BaseEngine):
         self.ticks: Dict[str, List[TickData]] = defaultdict(list)
         self.bars: Dict[str, List[BarData]] = defaultdict(list)
 
-        self.database: BaseDatabase = get_database()
+        self.database: BaseDatabase = self.get_database()
 
         self.load_setting()
         self.register_event()
         self.start()
         self.put_event()
+
+    def get_database(self) -> BaseDatabase:
+        return get_database()
 
     def load_setting(self) -> None:
         """"""


### PR DESCRIPTION
允许子类重写自定义数据库对象，而不是只能从vnpy.trader.database.get_database加载。建议get_database不要在任何需要获得数据库对象的类的构造函数中执行，避免get_database的调用无法被重写。可能造成MysqlDatabase率先实例化而不是其子类。